### PR TITLE
Fix terminology errors

### DIFF
--- a/input/examples/anthrax-example-PlanDefinition-AntimicrobialNotPregant-FHIRv400.json
+++ b/input/examples/anthrax-example-PlanDefinition-AntimicrobialNotPregant-FHIRv400.json
@@ -166,63 +166,6 @@
       "title": "Anthrax Post Exposure Prophylaxis",
       "groupingBehavior": "logical-group",
       "selectionBehavior": "any",
-      "trigger": [
-        {
-          "type": "data-added",
-          "data": [
-            {
-              "type": "Condition",
-              "codeFilter": [
-                {
-                  "path": "code",
-                  "code": [
-                    {
-                      "system": "http://hl7.org/fhir/sid/icd-10-cm",
-                      "code": "Z20.810",
-                      "display": "Contact with and (suspected) exposure to anthrax"
-                    },
-                    {
-                      "system": "http://snomed.info/sct",
-                      "code": "170475009",
-                      "display": "Exposure to Bacillus anthracis (event)"
-                    }
-                  ]
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "type": "data-added",
-          "data": [
-            {
-              "type": "Observation",
-              "codeFilter": [
-                {
-                  "path": "code",
-                  "code": [
-                    {
-                      "system": "http://hl7.org/fhir/sid/icd-10-cm",
-                      "code": "Z20.810",
-                      "display": "Contact with and (suspected) exposure to anthrax"
-                    },
-                    {
-                      "system": "http://snomed.info/sct",
-                      "code": "170475009",
-                      "display": "Exposure to Bacillus anthracis (event)"
-                    },
-                    {
-                      "system": "http://snomed.info/sct",
-                      "code": "84387000",
-                      "display": "Asymptomatic (finding)"
-                    }
-                  ]
-                }
-              ]
-            }
-          ]
-        }
-      ],
       "condition": [
         {
           "kind": "applicability",

--- a/input/examples/anthrax-example-PlanDefinition-AntimicrobialPregnant-FHIRv400.json
+++ b/input/examples/anthrax-example-PlanDefinition-AntimicrobialPregnant-FHIRv400.json
@@ -166,63 +166,6 @@
       "title": "Anthrax Post Exposure Prophylaxis",
       "groupingBehavior": "logical-group",
       "selectionBehavior": "any",
-      "trigger": [
-        {
-          "type": "data-added",
-          "data": [
-            {
-              "type": "Condition",
-              "codeFilter": [
-                {
-                  "path": "code",
-                  "code": [
-                    {
-                      "system": "http://hl7.org/fhir/sid/icd-10-cm",
-                      "code": "Z20.810",
-                      "display": "Contact with and (suspected) exposure to anthrax"
-                    },
-                    {
-                      "system": "http://snomed.info/sct",
-                      "code": "170475009",
-                      "display": "Exposure to Bacillus anthracis (event)"
-                    }
-                  ]
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "type": "data-added",
-          "data": [
-            {
-              "type": "Observation",
-              "codeFilter": [
-                {
-                  "path": "code",
-                  "code": [
-                    {
-                      "system": "http://hl7.org/fhir/sid/icd-10-cm",
-                      "code": "Z20.810",
-                      "display": "Contact with and (suspected) exposure to anthrax"
-                    },
-                    {
-                      "system": "http://snomed.info/sct",
-                      "code": "170475009",
-                      "display": "Exposure to Bacillus anthracis (event)"
-                    },
-                    {
-                      "system": "http://snomed.info/sct",
-                      "code": "84387000",
-                      "display": "Asymptomatic (finding)"
-                    }
-                  ]
-                }
-              ]
-            }
-          ]
-        }
-      ],
       "condition": [
         {
           "kind": "applicability",

--- a/input/examples/anthrax-example-PlanDefinition-FirstVaccineDoseAndAntimicrobialNotPregnant-FHIRv400.json
+++ b/input/examples/anthrax-example-PlanDefinition-FirstVaccineDoseAndAntimicrobialNotPregnant-FHIRv400.json
@@ -166,63 +166,6 @@
       "title": "Anthrax Post Exposure Prophylaxis",
       "groupingBehavior": "logical-group",
       "selectionBehavior": "any",
-      "trigger": [
-        {
-          "type": "data-added",
-          "data": [
-            {
-              "type": "Condition",
-              "codeFilter": [
-                {
-                  "path": "code",
-                  "code": [
-                    {
-                      "system": "http://hl7.org/fhir/sid/icd-10-cm",
-                      "code": "Z20.810",
-                      "display": "Contact with and (suspected) exposure to anthrax"
-                    },
-                    {
-                      "system": "http://snomed.info/sct",
-                      "code": "170475009",
-                      "display": "Exposure to Bacillus anthracis (event)"
-                    }
-                  ]
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "type": "data-added",
-          "data": [
-            {
-              "type": "Observation",
-              "codeFilter": [
-                {
-                  "path": "code",
-                  "code": [
-                    {
-                      "system": "http://hl7.org/fhir/sid/icd-10-cm",
-                      "code": "Z20.810",
-                      "display": "Contact with and (suspected) exposure to anthrax"
-                    },
-                    {
-                      "system": "http://snomed.info/sct",
-                      "code": "170475009",
-                      "display": "Exposure to Bacillus anthracis (event)"
-                    },
-                    {
-                      "system": "http://snomed.info/sct",
-                      "code": "84387000",
-                      "display": "Asymptomatic (finding)"
-                    }
-                  ]
-                }
-              ]
-            }
-          ]
-        }
-      ],
       "condition": [
         {
           "kind": "applicability",

--- a/input/examples/anthrax-example-PlanDefinition-FirstVaccineDoseAndAntimicrobialPregnant-FHIRv400.json
+++ b/input/examples/anthrax-example-PlanDefinition-FirstVaccineDoseAndAntimicrobialPregnant-FHIRv400.json
@@ -166,63 +166,6 @@
       "title": "Anthrax Post Exposure Prophylaxis",
       "groupingBehavior": "logical-group",
       "selectionBehavior": "any",
-      "trigger": [
-        {
-          "type": "data-added",
-          "data": [
-            {
-              "type": "Condition",
-              "codeFilter": [
-                {
-                  "path": "code",
-                  "code": [
-                    {
-                      "system": "http://hl7.org/fhir/sid/icd-10-cm",
-                      "code": "Z20.810",
-                      "display": "Contact with and (suspected) exposure to anthrax"
-                    },
-                    {
-                      "system": "http://snomed.info/sct",
-                      "code": "170475009",
-                      "display": "Exposure to Bacillus anthracis (event)"
-                    }
-                  ]
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "type": "data-added",
-          "data": [
-            {
-              "type": "Observation",
-              "codeFilter": [
-                {
-                  "path": "code",
-                  "code": [
-                    {
-                      "system": "http://hl7.org/fhir/sid/icd-10-cm",
-                      "code": "Z20.810",
-                      "display": "Contact with and (suspected) exposure to anthrax"
-                    },
-                    {
-                      "system": "http://snomed.info/sct",
-                      "code": "170475009",
-                      "display": "Exposure to Bacillus anthracis (event)"
-                    },
-                    {
-                      "system": "http://snomed.info/sct",
-                      "code": "84387000",
-                      "display": "Asymptomatic (finding)"
-                    }
-                  ]
-                }
-              ]
-            }
-          ]
-        }
-      ],
       "condition": [
         {
           "kind": "applicability",

--- a/input/examples/anthrax-example-PlanDefinition-FirstVaccineDoseNotPregnant-FHIRv400.json
+++ b/input/examples/anthrax-example-PlanDefinition-FirstVaccineDoseNotPregnant-FHIRv400.json
@@ -166,63 +166,6 @@
       "title": "Anthrax Post Exposure Prophylaxis",
       "groupingBehavior": "logical-group",
       "selectionBehavior": "any",
-      "trigger": [
-        {
-          "type": "data-added",
-          "data": [
-            {
-              "type": "Condition",
-              "codeFilter": [
-                {
-                  "path": "code",
-                  "code": [
-                    {
-                      "system": "http://hl7.org/fhir/sid/icd-10-cm",
-                      "code": "Z20.810",
-                      "display": "Contact with and (suspected) exposure to anthrax"
-                    },
-                    {
-                      "system": "http://snomed.info/sct",
-                      "code": "170475009",
-                      "display": "Exposure to Bacillus anthracis (event)"
-                    }
-                  ]
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "type": "data-added",
-          "data": [
-            {
-              "type": "Observation",
-              "codeFilter": [
-                {
-                  "path": "code",
-                  "code": [
-                    {
-                      "system": "http://hl7.org/fhir/sid/icd-10-cm",
-                      "code": "Z20.810",
-                      "display": "Contact with and (suspected) exposure to anthrax"
-                    },
-                    {
-                      "system": "http://snomed.info/sct",
-                      "code": "170475009",
-                      "display": "Exposure to Bacillus anthracis (event)"
-                    },
-                    {
-                      "system": "http://snomed.info/sct",
-                      "code": "84387000",
-                      "display": "Asymptomatic (finding)"
-                    }
-                  ]
-                }
-              ]
-            }
-          ]
-        }
-      ],
       "condition": [
         {
           "kind": "applicability",

--- a/input/examples/anthrax-example-PlanDefinition-FirstVaccineDosePregnant-FHIRv400.json
+++ b/input/examples/anthrax-example-PlanDefinition-FirstVaccineDosePregnant-FHIRv400.json
@@ -166,63 +166,6 @@
       "title": "Anthrax Post Exposure Prophylaxis",
       "groupingBehavior": "logical-group",
       "selectionBehavior": "any",
-      "trigger": [
-        {
-          "type": "data-added",
-          "data": [
-            {
-              "type": "Condition",
-              "codeFilter": [
-                {
-                  "path": "code",
-                  "code": [
-                    {
-                      "system": "http://hl7.org/fhir/sid/icd-10-cm",
-                      "code": "Z20.810",
-                      "display": "Contact with and (suspected) exposure to anthrax"
-                    },
-                    {
-                      "system": "http://snomed.info/sct",
-                      "code": "170475009",
-                      "display": "Exposure to Bacillus anthracis (event)"
-                    }
-                  ]
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "type": "data-added",
-          "data": [
-            {
-              "type": "Observation",
-              "codeFilter": [
-                {
-                  "path": "code",
-                  "code": [
-                    {
-                      "system": "http://hl7.org/fhir/sid/icd-10-cm",
-                      "code": "Z20.810",
-                      "display": "Contact with and (suspected) exposure to anthrax"
-                    },
-                    {
-                      "system": "http://snomed.info/sct",
-                      "code": "170475009",
-                      "display": "Exposure to Bacillus anthracis (event)"
-                    },
-                    {
-                      "system": "http://snomed.info/sct",
-                      "code": "84387000",
-                      "display": "Asymptomatic (finding)"
-                    }
-                  ]
-                }
-              ]
-            }
-          ]
-        }
-      ],
       "condition": [
         {
           "kind": "applicability",

--- a/input/examples/anthrax-example-PlanDefinition-SecondVaccineDoseAndAntimicrobialNotPregnant-FHIRv400.json
+++ b/input/examples/anthrax-example-PlanDefinition-SecondVaccineDoseAndAntimicrobialNotPregnant-FHIRv400.json
@@ -166,63 +166,6 @@
       "title": "Anthrax Post Exposure Prophylaxis",
       "groupingBehavior": "logical-group",
       "selectionBehavior": "any",
-      "trigger": [
-        {
-          "type": "data-added",
-          "data": [
-            {
-              "type": "Condition",
-              "codeFilter": [
-                {
-                  "path": "code",
-                  "code": [
-                    {
-                      "system": "http://hl7.org/fhir/sid/icd-10-cm",
-                      "code": "Z20.810",
-                      "display": "Contact with and (suspected) exposure to anthrax"
-                    },
-                    {
-                      "system": "http://snomed.info/sct",
-                      "code": "170475009",
-                      "display": "Exposure to Bacillus anthracis (event)"
-                    }
-                  ]
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "type": "data-added",
-          "data": [
-            {
-              "type": "Observation",
-              "codeFilter": [
-                {
-                  "path": "code",
-                  "code": [
-                    {
-                      "system": "http://hl7.org/fhir/sid/icd-10-cm",
-                      "code": "Z20.810",
-                      "display": "Contact with and (suspected) exposure to anthrax"
-                    },
-                    {
-                      "system": "http://snomed.info/sct",
-                      "code": "170475009",
-                      "display": "Exposure to Bacillus anthracis (event)"
-                    },
-                    {
-                      "system": "http://snomed.info/sct",
-                      "code": "84387000",
-                      "display": "Asymptomatic (finding)"
-                    }
-                  ]
-                }
-              ]
-            }
-          ]
-        }
-      ],
       "condition": [
         {
           "kind": "applicability",

--- a/input/examples/anthrax-example-PlanDefinition-SecondVaccineDoseAndAntimicrobialPregnant-FHIRv400.json
+++ b/input/examples/anthrax-example-PlanDefinition-SecondVaccineDoseAndAntimicrobialPregnant-FHIRv400.json
@@ -166,63 +166,6 @@
       "title": "Anthrax Post Exposure Prophylaxis",
       "groupingBehavior": "logical-group",
       "selectionBehavior": "any",
-      "trigger": [
-        {
-          "type": "data-added",
-          "data": [
-            {
-              "type": "Condition",
-              "codeFilter": [
-                {
-                  "path": "code",
-                  "code": [
-                    {
-                      "system": "http://hl7.org/fhir/sid/icd-10-cm",
-                      "code": "Z20.810",
-                      "display": "Contact with and (suspected) exposure to anthrax"
-                    },
-                    {
-                      "system": "http://snomed.info/sct",
-                      "code": "170475009",
-                      "display": "Exposure to Bacillus anthracis (event)"
-                    }
-                  ]
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "type": "data-added",
-          "data": [
-            {
-              "type": "Observation",
-              "codeFilter": [
-                {
-                  "path": "code",
-                  "code": [
-                    {
-                      "system": "http://hl7.org/fhir/sid/icd-10-cm",
-                      "code": "Z20.810",
-                      "display": "Contact with and (suspected) exposure to anthrax"
-                    },
-                    {
-                      "system": "http://snomed.info/sct",
-                      "code": "170475009",
-                      "display": "Exposure to Bacillus anthracis (event)"
-                    },
-                    {
-                      "system": "http://snomed.info/sct",
-                      "code": "84387000",
-                      "display": "Asymptomatic (finding)"
-                    }
-                  ]
-                }
-              ]
-            }
-          ]
-        }
-      ],
       "condition": [
         {
           "kind": "applicability",

--- a/input/examples/anthrax-example-PlanDefinition-SecondVaccineDoseNotPregnant-FHIRv400.json
+++ b/input/examples/anthrax-example-PlanDefinition-SecondVaccineDoseNotPregnant-FHIRv400.json
@@ -166,63 +166,6 @@
       "title": "Anthrax Post Exposure Prophylaxis",
       "groupingBehavior": "logical-group",
       "selectionBehavior": "any",
-      "trigger": [
-        {
-          "type": "data-added",
-          "data": [
-            {
-              "type": "Condition",
-              "codeFilter": [
-                {
-                  "path": "code",
-                  "code": [
-                    {
-                      "system": "http://hl7.org/fhir/sid/icd-10-cm",
-                      "code": "Z20.810",
-                      "display": "Contact with and (suspected) exposure to anthrax"
-                    },
-                    {
-                      "system": "http://snomed.info/sct",
-                      "code": "170475009",
-                      "display": "Exposure to Bacillus anthracis (event)"
-                    }
-                  ]
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "type": "data-added",
-          "data": [
-            {
-              "type": "Observation",
-              "codeFilter": [
-                {
-                  "path": "code",
-                  "code": [
-                    {
-                      "system": "http://hl7.org/fhir/sid/icd-10-cm",
-                      "code": "Z20.810",
-                      "display": "Contact with and (suspected) exposure to anthrax"
-                    },
-                    {
-                      "system": "http://snomed.info/sct",
-                      "code": "170475009",
-                      "display": "Exposure to Bacillus anthracis (event)"
-                    },
-                    {
-                      "system": "http://snomed.info/sct",
-                      "code": "84387000",
-                      "display": "Asymptomatic (finding)"
-                    }
-                  ]
-                }
-              ]
-            }
-          ]
-        }
-      ],
       "condition": [
         {
           "kind": "applicability",

--- a/input/examples/anthrax-example-PlanDefinition-SecondVaccineDosePregnant-FHIRv400.json
+++ b/input/examples/anthrax-example-PlanDefinition-SecondVaccineDosePregnant-FHIRv400.json
@@ -166,63 +166,6 @@
       "title": "Anthrax Post Exposure Prophylaxis",
       "groupingBehavior": "logical-group",
       "selectionBehavior": "any",
-      "trigger": [
-        {
-          "type": "data-added",
-          "data": [
-            {
-              "type": "Condition",
-              "codeFilter": [
-                {
-                  "path": "code",
-                  "code": [
-                    {
-                      "system": "http://hl7.org/fhir/sid/icd-10-cm",
-                      "code": "Z20.810",
-                      "display": "Contact with and (suspected) exposure to anthrax"
-                    },
-                    {
-                      "system": "http://snomed.info/sct",
-                      "code": "170475009",
-                      "display": "Exposure to Bacillus anthracis (event)"
-                    }
-                  ]
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "type": "data-added",
-          "data": [
-            {
-              "type": "Observation",
-              "codeFilter": [
-                {
-                  "path": "code",
-                  "code": [
-                    {
-                      "system": "http://hl7.org/fhir/sid/icd-10-cm",
-                      "code": "Z20.810",
-                      "display": "Contact with and (suspected) exposure to anthrax"
-                    },
-                    {
-                      "system": "http://snomed.info/sct",
-                      "code": "170475009",
-                      "display": "Exposure to Bacillus anthracis (event)"
-                    },
-                    {
-                      "system": "http://snomed.info/sct",
-                      "code": "84387000",
-                      "display": "Asymptomatic (finding)"
-                    }
-                  ]
-                }
-              ]
-            }
-          ]
-        }
-      ],
       "condition": [
         {
           "kind": "applicability",

--- a/input/examples/anthrax-example-PlanDefinition-ThirdVaccineDoseAndAntimicrobialNotPregnant-FHIRv400.json
+++ b/input/examples/anthrax-example-PlanDefinition-ThirdVaccineDoseAndAntimicrobialNotPregnant-FHIRv400.json
@@ -166,63 +166,6 @@
       "title": "Anthrax Post Exposure Prophylaxis",
       "groupingBehavior": "logical-group",
       "selectionBehavior": "any",
-      "trigger": [
-        {
-          "type": "data-added",
-          "data": [
-            {
-              "type": "Condition",
-              "codeFilter": [
-                {
-                  "path": "code",
-                  "code": [
-                    {
-                      "system": "http://hl7.org/fhir/sid/icd-10-cm",
-                      "code": "Z20.810",
-                      "display": "Contact with and (suspected) exposure to anthrax"
-                    },
-                    {
-                      "system": "http://snomed.info/sct",
-                      "code": "170475009",
-                      "display": "Exposure to Bacillus anthracis (event)"
-                    }
-                  ]
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "type": "data-added",
-          "data": [
-            {
-              "type": "Observation",
-              "codeFilter": [
-                {
-                  "path": "code",
-                  "code": [
-                    {
-                      "system": "http://hl7.org/fhir/sid/icd-10-cm",
-                      "code": "Z20.810",
-                      "display": "Contact with and (suspected) exposure to anthrax"
-                    },
-                    {
-                      "system": "http://snomed.info/sct",
-                      "code": "170475009",
-                      "display": "Exposure to Bacillus anthracis (event)"
-                    },
-                    {
-                      "system": "http://snomed.info/sct",
-                      "code": "84387000",
-                      "display": "Asymptomatic (finding)"
-                    }
-                  ]
-                }
-              ]
-            }
-          ]
-        }
-      ],
       "condition": [
         {
           "kind": "applicability",

--- a/input/examples/anthrax-example-PlanDefinition-ThirdVaccineDoseAndAntimicrobialPregnant-FHIRv400.json
+++ b/input/examples/anthrax-example-PlanDefinition-ThirdVaccineDoseAndAntimicrobialPregnant-FHIRv400.json
@@ -166,63 +166,6 @@
       "title": "Anthrax Post Exposure Prophylaxis",
       "groupingBehavior": "logical-group",
       "selectionBehavior": "any",
-      "trigger": [
-        {
-          "type": "data-added",
-          "data": [
-            {
-              "type": "Condition",
-              "codeFilter": [
-                {
-                  "path": "code",
-                  "code": [
-                    {
-                      "system": "http://hl7.org/fhir/sid/icd-10-cm",
-                      "code": "Z20.810",
-                      "display": "Contact with and (suspected) exposure to anthrax"
-                    },
-                    {
-                      "system": "http://snomed.info/sct",
-                      "code": "170475009",
-                      "display": "Exposure to Bacillus anthracis (event)"
-                    }
-                  ]
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "type": "data-added",
-          "data": [
-            {
-              "type": "Observation",
-              "codeFilter": [
-                {
-                  "path": "code",
-                  "code": [
-                    {
-                      "system": "http://hl7.org/fhir/sid/icd-10-cm",
-                      "code": "Z20.810",
-                      "display": "Contact with and (suspected) exposure to anthrax"
-                    },
-                    {
-                      "system": "http://snomed.info/sct",
-                      "code": "170475009",
-                      "display": "Exposure to Bacillus anthracis (event)"
-                    },
-                    {
-                      "system": "http://snomed.info/sct",
-                      "code": "84387000",
-                      "display": "Asymptomatic (finding)"
-                    }
-                  ]
-                }
-              ]
-            }
-          ]
-        }
-      ],
       "condition": [
         {
           "kind": "applicability",

--- a/input/examples/anthrax-example-PlanDefinition-ThirdVaccineDoseNotPregnant-FHIRv400.json
+++ b/input/examples/anthrax-example-PlanDefinition-ThirdVaccineDoseNotPregnant-FHIRv400.json
@@ -166,63 +166,6 @@
       "title": "Anthrax Post Exposure Prophylaxis",
       "groupingBehavior": "logical-group",
       "selectionBehavior": "any",
-      "trigger": [
-        {
-          "type": "data-added",
-          "data": [
-            {
-              "type": "Condition",
-              "codeFilter": [
-                {
-                  "path": "code",
-                  "code": [
-                    {
-                      "system": "http://hl7.org/fhir/sid/icd-10-cm",
-                      "code": "Z20.810",
-                      "display": "Contact with and (suspected) exposure to anthrax"
-                    },
-                    {
-                      "system": "http://snomed.info/sct",
-                      "code": "170475009",
-                      "display": "Exposure to Bacillus anthracis (event)"
-                    }
-                  ]
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "type": "data-added",
-          "data": [
-            {
-              "type": "Observation",
-              "codeFilter": [
-                {
-                  "path": "code",
-                  "code": [
-                    {
-                      "system": "http://hl7.org/fhir/sid/icd-10-cm",
-                      "code": "Z20.810",
-                      "display": "Contact with and (suspected) exposure to anthrax"
-                    },
-                    {
-                      "system": "http://snomed.info/sct",
-                      "code": "170475009",
-                      "display": "Exposure to Bacillus anthracis (event)"
-                    },
-                    {
-                      "system": "http://snomed.info/sct",
-                      "code": "84387000",
-                      "display": "Asymptomatic (finding)"
-                    }
-                  ]
-                }
-              ]
-            }
-          ]
-        }
-      ],
       "condition": [
         {
           "kind": "applicability",

--- a/input/examples/anthrax-example-PlanDefinition-ThirdVaccineDosePregnant-FHIRv400.json
+++ b/input/examples/anthrax-example-PlanDefinition-ThirdVaccineDosePregnant-FHIRv400.json
@@ -166,63 +166,6 @@
       "title": "Anthrax Post Exposure Prophylaxis",
       "groupingBehavior": "logical-group",
       "selectionBehavior": "any",
-      "trigger": [
-        {
-          "type": "data-added",
-          "data": [
-            {
-              "type": "Condition",
-              "codeFilter": [
-                {
-                  "path": "code",
-                  "code": [
-                    {
-                      "system": "http://hl7.org/fhir/sid/icd-10-cm",
-                      "code": "Z20.810",
-                      "display": "Contact with and (suspected) exposure to anthrax"
-                    },
-                    {
-                      "system": "http://snomed.info/sct",
-                      "code": "170475009",
-                      "display": "Exposure to Bacillus anthracis (event)"
-                    }
-                  ]
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "type": "data-added",
-          "data": [
-            {
-              "type": "Observation",
-              "codeFilter": [
-                {
-                  "path": "code",
-                  "code": [
-                    {
-                      "system": "http://hl7.org/fhir/sid/icd-10-cm",
-                      "code": "Z20.810",
-                      "display": "Contact with and (suspected) exposure to anthrax"
-                    },
-                    {
-                      "system": "http://snomed.info/sct",
-                      "code": "170475009",
-                      "display": "Exposure to Bacillus anthracis (event)"
-                    },
-                    {
-                      "system": "http://snomed.info/sct",
-                      "code": "84387000",
-                      "display": "Asymptomatic (finding)"
-                    }
-                  ]
-                }
-              ]
-            }
-          ]
-        }
-      ],
       "condition": [
         {
           "kind": "applicability",

--- a/input/fsh/rules.fsh
+++ b/input/fsh/rules.fsh
@@ -1,5 +1,4 @@
 RuleSet: CodeSystemMetadata(id-prefix)
-* ^meta.profile = $cpg-publishable-codesystem
 * ^extension[+].url = $cpg-knowledgeCapability
 * ^extension[=].valueCode = #shareable
 * ^extension[+].url = $cpg-knowledgeCapability
@@ -23,7 +22,6 @@ RuleSet: CodeSystemDates(approvalDate, effectiveDate, lastReviewDate )
 * ^extension[=].valueDate = {lastReviewDate}
 
 RuleSet: ValueSetMetadata(id)
-* ^meta.profile = $cpg-publishable-valueset
 * ^extension[+].url = $cpg-knowledgeCapability
 * ^extension[=].valueCode = #shareable
 * ^extension[+].url = $cpg-knowledgeCapability


### PR DESCRIPTION
- Removed meta.profile on terminology. Meta.profile on ValueSets and CodeSystems caused these to display as examples. 
- Temporarily removed DataRequirement type code filters on Anthrax plan definition triggers. These examples caused publishing errors on all terminology: 
`"org.hl7.fhir.r5.model.DataRequirement$DataRequirementCodeFilterComponent.getValueSet()" is null`

I plan to investigate the issue with the anthrax examples further, but these changes will allow terminology to publish successfully for now. Specifying codeFilter.valueSet resolves the errors as well, but it is unclear why the valueset is necessary in addition to providing specific codes for the filter. Based on documentation, either a code or valueSet can be used https://hl7.org/fhir/R4/metadatatypes-definitions.html#DataRequirement.codeFilter.code