### PR TITLE
Add PlanDefinition.action as context for cpg-rationale extension

### DIFF
--- a/FHIR-cpg.xml
+++ b/FHIR-cpg.xml
@@ -606,6 +606,7 @@
 <page key="toc" name="Table of Contents"/>
 <page key="terminology" name="Terminology"/>
 <page key="documentation-approach-07-tiers-of-functionality" name="Tiers of Functionality"/>
+<page deprecated="true" key="changes" name="Version History"/>
 <page key="documentation-approach-12-06-cpg-common-pathway" name="Workflow and Common Pathway"/>
 <page key="documentation-approach-06-01-levels-of-knowledge-representation" name="“Levels” of Knowledge Representation Framing"/>
 </specification>

--- a/input/fsh/extensions/extension-cpg-rationale.fsh
+++ b/input/fsh/extensions/extension-cpg-rationale.fsh
@@ -4,4 +4,5 @@ Title: "CPG Rationale Extension"
 Description: "A clinician-friendly explanation for the recommendation; patient-friendly if the recommendation is patient-facing."
 * insert StructureDefinitionMetadata(cpg-rationale)
 * insert ExtensionContext(Resource)
+* insert ExtensionContext(PlanDefinition.action)
 * value[x] only markdown


### PR DESCRIPTION
CPG Rationale should be allowed on PlanDefinition.action as context. See FSH generated json below.
<img width="535" alt="Screenshot 2024-09-26 at 4 31 04 PM" src="https://github.com/user-attachments/assets/9f3a6e90-2537-4508-875b-ee7977c65170">
