### PR TITLE
FHIR-46097 Allow cpg rationale on plandefinition.action

### DIFF
--- a/input/fsh/extensions/extension-cpg-rationale.fsh
+++ b/input/fsh/extensions/extension-cpg-rationale.fsh
@@ -4,4 +4,5 @@ Title: "CPG Rationale Extension"
 Description: "A clinician-friendly explanation for the recommendation; patient-friendly if the recommendation is patient-facing."
 * insert StructureDefinitionMetadata(cpg-rationale)
 * insert ExtensionContext(Resource)
+* insert ExtensionContext(PlanDefinition.action)
 * value[x] only markdown


### PR DESCRIPTION
CPG Rationale extension should be allowed on PlanDefinition.action as context, not just Resource. See FSH generated JSON

<img width="535" alt="Screenshot 2024-09-26 at 4 31 04 PM" src="https://github.com/user-attachments/assets/29e1c79b-f509-43f0-b824-9f5b4bac5245">
