### PR TITLE
FHIR-48388-RecommendationDefinition-should-allow-definitionCanonical-CPGOrderSetDefinition

### DIFF
--- a/input/fsh/profiles/domain-profiles/cpg-ordersetdefinition.fsh
+++ b/input/fsh/profiles/domain-profiles/cpg-ordersetdefinition.fsh
@@ -8,8 +8,6 @@ Description: "Profile of PlanDefinition as a Order Set for use with CPG Implemen
 * type MS
 * action MS
   * title 1..1 MS
-  * input 0..0
-  * output 0..0
   * groupingBehavior MS
   * selectionBehavior MS
   * requiredBehavior MS

--- a/input/fsh/profiles/domain-profiles/cpg-recommendationdefinition.fsh
+++ b/input/fsh/profiles/domain-profiles/cpg-recommendationdefinition.fsh
@@ -17,5 +17,5 @@ Description: "Profile of PlanDefinition as a Recommendation Definition for use w
     * ^definition = "For recommendation definitions, the output element is used to specify what information should be included as patient-specific supporting evidence for the recommendation."
     * ^comment = "If output elements are specified, implementations SHOULD support attaching content matching the output data requirements to the recommendation instances as appropriate for the recommendation resource type, typically a supportingInformation element."
 * action
-  * definition[x] only Canonical(ActivityDefinition)
+  * definition[x] only Canonical(ActivityDefinition or CPGOrderSetDefinition)
   * definitionCanonical MS


### PR DESCRIPTION
[FHIR-48388](https://jira.hl7.org/browse/FHIR-48388)

Allow CPGRecommendationDefinition action.definition element to reference a CPGOrderSetDefinition

Remove cardinality restrictions for action.input and action.output of CPGOrderSetDefinition